### PR TITLE
Add MockJSONAPIClient class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# CHANGELOG
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.2.0] - 2016-07-06
+### Added
+- Class `MockJSONAPIClient`.
+
+## [0.0.1] - 2016-07-05
+Initial version.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,26 @@ Used to create a document containing a JSON API resource.
 Used to delete a resource.
 
 `Future delete(String url, {Map headers})`
+
+
+## Tests
+
+You can test your application which uses JSONAPIClient by using the included `MockJSONAPIClient` class.
+
+```
+MockJSONAPIClient mockClient = new MockJSONAPIClient();
+JSONAPIDocument mockDocument = new JSONAPIDocument({
+  "data": {
+      "id": "1",
+      "type": "persons",
+      "attributes": {
+        "name": "Gianfranco",
+        "surname": "Reppucci"
+      }
+    }
+});
+
+mockClient.setOutput(mockDocument);
+
+mockClient.get('http://mockapi.test/persons/1') // will return mockDocument as output
+```

--- a/lib/jsonapi_client.dart
+++ b/lib/jsonapi_client.dart
@@ -6,3 +6,4 @@ export 'src/document.dart';
 export 'src/resource.dart';
 export 'src/error.dart';
 export 'src/client.dart';
+export 'src/mock_client.dart';

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2016, Qurami team.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'client.dart';
+import 'document.dart';
+
+class MockJSONAPIClient implements JSONAPIClient {
+  var request; // unused
+
+  var _desiredOutput;
+
+  setOutput(dynamic output){
+    _desiredOutput = output;
+  }
+
+  Future<JSONAPIDocument> get(String url,
+      {List<String> includeModels, Map headers}) async {
+        return new Future.value(_desiredOutput);
+      }
+
+  Future<JSONAPIDocument> post(String url, String document,
+    {List<String> includeModels, Map headers}) async {
+      return new Future.value(_desiredOutput);
+    }
+
+  Future delete(String url, {Map headers}) async {
+    return new Future.value(_desiredOutput);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: jsonapi_client
-version: 0.0.1
+version: 0.2.0
 environment:
   sdk: '>=1.13.0 <2.0.0'
 description: >

--- a/test/mock_client_test.dart
+++ b/test/mock_client_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, Qurami team.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import "package:test/test.dart";
+import "package:jsonapi_client/jsonapi_client.dart";
+
+void main() {
+  group("test MockJSONAPIClient", () {
+    JSONAPIDocument d = new JSONAPIDocument({
+      'data': {
+        'type': 'persons',
+        'id': '1',
+        'attributes': {
+          'name': 'Gianfranco',
+          'surname': 'Reppucci'
+        }
+      }
+    });
+
+    test("client get method returns the input value using setOutput", () async {
+      MockJSONAPIClient c = new MockJSONAPIClient();
+
+      c.setOutput(d);
+
+      JSONAPIDocument expectedDocument = await c.get('http://mockapi.test/persons/1');
+      expect(expectedDocument.toJson(), equals(d.toJson()));
+    });
+
+    test("client post method returns the input value using setOutput", () async {
+      MockJSONAPIClient c = new MockJSONAPIClient();
+
+      c.setOutput(d);
+
+      Map inputDocument = d.toJson();
+      inputDocument['data'].remove('id');
+
+      JSONAPIDocument expectedDocument = await c.post('http://mockapi.test/persons', JSON.encode(inputDocument));
+      expect(expectedDocument.toJson(), equals(d.toJson()));
+    });
+
+    test("client delete method returns the input value using setOutput", () async {
+      MockJSONAPIClient c = new MockJSONAPIClient();
+
+      c.setOutput(d);
+
+      JSONAPIDocument expectedDocument = await c.delete('http://mockapi.test/persons/1');
+      expect(expectedDocument.toJson(), equals(d.toJson()));
+    });
+  });
+}


### PR DESCRIPTION
This branch introduces the `MockJSONAPIClient` class, useful to test the applications which use the JSONAPIClient library.

Usage included in `README.md` file
