### PR TITLE
add a factory for jsonapi resources and custom subclasses

### DIFF
--- a/lib/jsonapi_client.dart
+++ b/lib/jsonapi_client.dart
@@ -7,3 +7,5 @@ export 'src/resource.dart';
 export 'src/error.dart';
 export 'src/client.dart';
 export 'src/mock_client.dart';
+export 'src/resource_factory.dart';
+export 'src/factory_buildable_object.dart';

--- a/lib/src/factory_buildable_object.dart
+++ b/lib/src/factory_buildable_object.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2016, Qurami team.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+abstract class FactoryBuildableObject {
+  /// returns a Map of json-to-property bindings
+  ///
+  /// this method is used to associate a json key to the property name of the
+  /// object implementing the interface
+  /// There is no need to override this method or return anything if object's property
+  /// names are equal to the json value provided.
+  Map<String, String> getPropertyBindingMap();
+
+  /// returns an array of json-to-property data validator
+  ///
+  /// can be used to validate data or to instantiate custom non-json object types
+  Map<String, Function> getPropertyValidatorMap();
+}

--- a/lib/src/resource_factory.dart
+++ b/lib/src/resource_factory.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2016, Qurami team.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+import 'dart:mirrors';
+import 'factory_buildable_object.dart';
+import 'resource.dart';
+
+class JSONAPIResourceFactory {
+  Map<String, ClassMirror> typeToClassMap = new Map<String, ClassMirror>();
+
+  /// binds a provided ClassMirror to a JSONAPIResource type
+  ///
+  /// the [inputClass] gets stored and the used to instantiate
+  /// every JSONAPIResource of matching [type]
+  ///
+  /// Throws an [ArgumentError] if parameters aren't provided.
+  void bindClassMirrorToResourceOfType(ClassMirror inputClass, String type) {
+    if (inputClass == null || type == null || type.length == 0) {
+      throw new ArgumentError('inputClass and type parameters are mandatory');
+    }
+    typeToClassMap[type] = inputClass;
+  }
+
+  /// validates a [jsonapiResourceMap] to check if cointains mandatory fields
+  /// for initializing a [JSONAPIResource]
+  ///
+  /// Throws an [Exception] if [jsonAPIResourceMap] is malformed
+  static _validateJSONAPIResourceMap(Map jsonAPIResourceMap) {
+    if (!jsonAPIResourceMap.containsKey('id') ||
+        !jsonAPIResourceMap.containsKey('type')) {
+      throw new Exception("malformed jsonapi resource map passed to factory");
+    }
+  }
+
+  /// instantiates an object with [jsonAPIResourceMap]
+  ///
+  /// the object class will be custom if previously bound with [bindClassMirrorToResourceOfType]
+  /// or [JSONAPIResource] otherwise.
+  instantiateObjectWithJSONAPIResourceMap(Map jsonAPIResourceMap) {
+    _validateJSONAPIResourceMap(jsonAPIResourceMap);
+
+    String classType = jsonAPIResourceMap['type'];
+    ClassMirror associatedClassMirror = typeToClassMap[classType];
+
+    // if no associated class mirror is found a JSONAPIResource is returned
+    if (associatedClassMirror != null) {
+      // a subclass corresponding to the passed class mirror gets instantiated
+      // and every property gets initialized with the attributes in the jsonAPIMap
+      var newResource = associatedClassMirror
+          .newInstance(new Symbol(''), [jsonAPIResourceMap]).reflectee;
+      if (jsonAPIResourceMap.containsKey('attributes')) {
+        Map attributes = jsonAPIResourceMap['attributes'];
+        for (String key in attributes.keys) {
+          _setJSONAPIResourcePropertyWithValue(
+              newResource, key, attributes[key]);
+        }
+      }
+
+      return newResource;
+    } else {
+      JSONAPIResource newResource = new JSONAPIResource(jsonAPIResourceMap);
+      return newResource;
+    }
+  }
+
+  /// sets the property of name [key] to the passed [resource]
+  /// with the passed [value]. Uses reflection to work on [JSONAPIResource] subclsses.
+  ///
+  /// throws an [ArgumentError] if no [key] or [resource] are provided (null [value] is accepted instead).
+  /// throws an [Exception] if there is no property declared on [resource] for the provided [key].
+  static _setJSONAPIResourcePropertyWithValue(
+      FactoryBuildableObject resource, String key, value) {
+    if (resource == null || key == null) {
+      throw new ArgumentError('key and resource parameters are mandatory');
+    }
+    if (value != null) {
+      // checks if there is a custom property binding map provided.
+      Map propertyAssociation = resource.getPropertyBindingMap();
+      if (propertyAssociation == null) {
+        propertyAssociation = {};
+      }
+
+      // checks if there is a custom property validator map provided.
+      Map propertyValidator = resource.getPropertyValidatorMap();
+      if (propertyValidator == null) {
+        propertyValidator = {};
+      }
+
+      // gets the string corresponding to the property to be set
+      // using the one provided on the custom map or the provided key if not present.
+      String propertyName = (propertyAssociation.containsKey(key))
+          ? propertyAssociation[key]
+          : key;
+
+      // gets the value to be set
+      // using the one provided one as it is if no validating function is passed.
+      var propertyValue = (propertyValidator.containsKey(key))
+          ? propertyValidator[key](value)
+          : value;
+
+      //sets the property
+      InstanceMirror reflectableInstance = reflect(resource);
+      Symbol property = new Symbol(propertyName);
+      if (MirrorSystem.getName(property) != null) {
+        reflectableInstance.setField(property, propertyValue);
+      } else {
+        throw new Exception(
+            'jsonapi resource subclass has no property of key' + key);
+      }
+    }
+  }
+}

--- a/test/resource_factory_test.dart
+++ b/test/resource_factory_test.dart
@@ -1,0 +1,182 @@
+@Timeout(const Duration(seconds: 600))
+import 'package:test/test.dart';
+import 'dart:mirrors';
+import 'package:jsonapi_client/jsonapi_client.dart';
+
+//TODO: Remove
+import 'package:jsonapi_client/src/factory_buildable_object.dart';
+
+class MockClass extends JSONAPIResource with FactoryBuildableObject {
+  String standardStringAttribute;
+  Map standardMapAttribute;
+  int standardIntAttribute;
+  String propertyWithDifferentName;
+  String propertyThatGetsProcessedByValidator;
+
+  MockClass(Map jsonMap) : super(jsonMap);
+
+  getPropertyBindingMap() {
+    return {"propertyWithJsonName": "propertyWithDifferentName"};
+  }
+
+  getPropertyValidatorMap() {
+    return {
+      "propertyThatGetsProcessedByValidator": (String value) {
+        return value + " addition";
+      }
+    };
+  }
+}
+
+void main() {
+  JSONAPIResourceFactory sut;
+  setUp(() {
+    sut = new JSONAPIResourceFactory();
+  });
+
+  tearDown(() {
+    sut = null;
+  });
+
+  test("test that class mirror gets associated", () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    expect(sut.typeToClassMap['mock-type'], equals(cm));
+  });
+
+  test("test that throws if no class mirror is provided", () {
+    ArgumentError expectedException = null;
+    try {
+      sut.bindClassMirrorToResourceOfType(null, 'mock-type');
+    } catch (e) {
+      expectedException = e;
+    }
+    expect(expectedException, isNotNull);
+  });
+
+  test("test that throws if no type is provided", () {
+    ClassMirror cm = reflectClass(MockClass);
+    ArgumentError expectedException = null;
+    try {
+      sut.bindClassMirrorToResourceOfType(cm, null);
+    } catch (e) {
+      expectedException = e;
+    }
+    expect(expectedException, isNotNull);
+  });
+
+  test("test that throws if type provided is zero length", () {
+    ClassMirror cm = reflectClass(MockClass);
+    ArgumentError expectedException = null;
+    try {
+      sut.bindClassMirrorToResourceOfType(cm, '');
+    } catch (e) {
+      expectedException = e;
+    }
+    expect(expectedException, isNotNull);
+  });
+
+  test("test that sut throws if jsonapi map is malformed", () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    Map malformedMap = {"malformation": "isBad"};
+    Exception expectedException = null;
+    try {
+      sut.instantiateObjectWithJSONAPIResourceMap(malformedMap);
+    } catch (e) {
+      expectedException = e;
+    }
+    expect(expectedException, isNotNull);
+  });
+
+  test(
+      "test that sut returns a JSONAPIResource if no associated class is found",
+      () {
+    Map mockMap = {"id": "1234", "type": "mock-type"};
+    var returnedObject = sut.instantiateObjectWithJSONAPIResourceMap(mockMap);
+    expect((returnedObject is JSONAPIResource), isTrue);
+  });
+
+  test("test that sut returns object with right class", () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    Map mockMap = {"id": "1234", "type": "mock-type"};
+    var returnedObject = sut.instantiateObjectWithJSONAPIResourceMap(mockMap);
+    expect(returnedObject is MockClass, isTrue);
+  });
+
+  test("test that sut initalizes object with default properties", () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    Map mockMap = {"id": "1234", "type": "mock-type"};
+    JSONAPIResource returnedObject =
+        sut.instantiateObjectWithJSONAPIResourceMap(mockMap);
+    expect(returnedObject.id, equals('1234'));
+    expect(returnedObject.type, equals('mock-type'));
+  });
+
+  test("test that sut initalizes object with attribute properties", () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    Map mockMap = {
+      "id": "1234",
+      "type": "mock-type",
+      "attributes": {
+        "standardStringAttribute": "mockString",
+        "standardMapAttribute": {"one": 1, "two": "2"},
+        "standardIntAttribute": 3
+      }
+    };
+
+    MockClass returnedObject =
+        sut.instantiateObjectWithJSONAPIResourceMap(mockMap);
+    expect(returnedObject.standardStringAttribute, equals('mockString'));
+    expect(returnedObject.standardMapAttribute, equals({"one": 1, "two": "2"}));
+    expect(returnedObject.standardIntAttribute, equals(3));
+  });
+
+  test(
+      "test that sut initalizes object with attribute properties in association map",
+      () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    Map mockMap = {
+      "id": "1234",
+      "type": "mock-type",
+      "attributes": {
+        "standardStringAttribute": "mockString",
+        "standardMapAttribute": {"one": 1, "two": "2"},
+        "standardIntAttribute": 3,
+        "propertyWithJsonName": "they are different but they love each other"
+      }
+    };
+
+    MockClass returnedObject =
+        sut.instantiateObjectWithJSONAPIResourceMap(mockMap);
+    expect(returnedObject.propertyWithDifferentName,
+        equals('they are different but they love each other'));
+  });
+
+  test(
+      "test that sut initalizes object with attribute properties in validator map",
+      () {
+    ClassMirror cm = reflectClass(MockClass);
+    sut.bindClassMirrorToResourceOfType(cm, 'mock-type');
+    Map mockMap = {
+      "id": "1234",
+      "type": "mock-type",
+      "attributes": {
+        "standardStringAttribute": "mockString",
+        "standardMapAttribute": {"one": 1, "two": "2"},
+        "standardIntAttribute": 3,
+        "propertyWithJsonName": "they are different but they love each other",
+        "propertyThatGetsProcessedByValidator": "expecting"
+      }
+    };
+
+    MockClass returnedObject =
+        sut.instantiateObjectWithJSONAPIResourceMap(mockMap);
+    expect(returnedObject.propertyThatGetsProcessedByValidator,
+        equals('expecting addition'));
+  });
+}


### PR DESCRIPTION
With the `JSONAPIResourceFactory` is possible to instantiate `JSONAPIResources` and custom Objects extending `JSONAPIResource`  and implementing the `FactoryBuildableObject` interface.

The usage is the following:

```
class MyClass extends JSONAPIResource with FactoryBuildableObject {
  String standardStringAttribute;
  String propertyWithDifferentName;
  String propertyThatGetsProcessedByValidator;

  MyClass(Map jsonMap) : super(jsonMap);

  getPropertyBindingMap() {
    return {"propertyWithJsonName": "propertyWithDifferentName"};
  }

  getPropertyValidatorMap() {
    return {
      "propertyThatGetsProcessedByValidator": (String value) {
        return value + " addition";
      }
    };
  }
}

void main(){
   JSONAPIResourceFactory myFactory = new JSONAPIResourceFactory();
   myFactory.bindClassMirrorToResourceOfType(reflectClass(MyClass), 'myclass-type');
   Map jsonMap = {
      "id": "1234",
      "type": "myclass-type",
      "attributes": {
        "standardStringAttribute": "mockString",
        "propertyWithJsonName",
        "propertyThatGetsProcessedByValidator":  "expecting"
      }

  //returned object will be an instance of MyClass
   var returnedObject = myFactory.instantiateObjectWithJSONAPIResourceMap(jsonMap)

}
```

To enable reflection the factory has a dependency on `'dart:mirrors'`.
